### PR TITLE
Add separation between frontend and backend services schemas

### DIFF
--- a/src/main/avro/AlumniSchemasAmbiguous.avsc
+++ b/src/main/avro/AlumniSchemasAmbiguous.avsc
@@ -1,71 +1,48 @@
+// alumnischemasambiguous.avsc
 [
-
-    {
-        "type": "record",
-        "namespace": "org.acme.avro.ambiguous.model",
-        "name": "AlumniGroupDto",
-        "fields":[
-            {
-                "name":"id", "type":"int"
-            },
-            {
-                "name":"faculty", "type":"string"
-            },
-            {
-                "name":"group_number", "type":"int"
-            },
-            {
-                "name":"graduation_year", "type":"int"
-            },
-            {
-                "name":"speciality_name", "type":"string"
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "name": "Degree",
-        "namespace": "org.acme.avro.ambiguous.model",
-        "fields": [
-            {
-            "name": "id",
-            "type": "int"
-            },
-            {
-            "name": "degreeName",
-            "type": "string"
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "name": "Speciality",
-        "namespace": "org.acme.avro.ambiguous.model",
-        "fields": [
-            {
-            "name": "id",
-            "type": "int"
-            },
-            {
-            "name": "specialityName",
-            "type": "string"
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "name": "Faculty",
-        "namespace": "org.acme.avro.ambiguous.model",
-        "fields": [
-            {
-            "name": "id",
-            "type": "int"
-            },
-            {
-            "name": "facultyName",
-            "type": "string"
-            }
-        ]
-    }
-
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.ambiguous.model",
+    "name": "AlumniGroupDto",
+    "fields": [
+      { "name": "id", "type": "int" },
+      {
+        "name": "faculty",
+        "type": "org.acme.avro.ambiguous.model.Faculty"
+      },
+      { "name": "groupNumber", "type": "int" },
+      { "name": "graduationYear", "type": "int" },
+      {
+        "name": "speciality",
+        "type": "org.acme.avro.ambiguous.model.Speciality"
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "Degree",
+    "namespace": "org.acme.avro.ambiguous.model",
+    "fields": [
+      { "name": "id", "type": "int" },
+      { "name": "degreeName", "type": "string" }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "Speciality",
+    "namespace": "org.acme.avro.ambiguous.model",
+    "fields": [
+      { "name": "id", "type": "int" },
+      { "name": "specialityName", "type": "string" }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "Faculty",
+    "namespace": "org.acme.avro.ambiguous.model",
+    "fields": [
+      { "name": "id", "type": "int" },
+      { "name": "facultyName", "type": "string" }
+    ]
+  }
 ]

--- a/src/main/avro/AlumniSchemasAmbiguous.avsc
+++ b/src/main/avro/AlumniSchemasAmbiguous.avsc
@@ -1,0 +1,71 @@
+[
+
+    {
+        "type": "record",
+        "namespace": "org.acme.avro.ambiguous.model",
+        "name": "AlumniGroupDto",
+        "fields":[
+            {
+                "name":"id", "type":"int"
+            },
+            {
+                "name":"faculty", "type":"string"
+            },
+            {
+                "name":"group_number", "type":"int"
+            },
+            {
+                "name":"graduation_year", "type":"int"
+            },
+            {
+                "name":"speciality_name", "type":"string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Degree",
+        "namespace": "org.acme.avro.ambiguous.model",
+        "fields": [
+            {
+            "name": "id",
+            "type": "int"
+            },
+            {
+            "name": "degreeName",
+            "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Speciality",
+        "namespace": "org.acme.avro.ambiguous.model",
+        "fields": [
+            {
+            "name": "id",
+            "type": "int"
+            },
+            {
+            "name": "specialityName",
+            "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Faculty",
+        "namespace": "org.acme.avro.ambiguous.model",
+        "fields": [
+            {
+            "name": "id",
+            "type": "int"
+            },
+            {
+            "name": "facultyName",
+            "type": "string"
+            }
+        ]
+    }
+
+]

--- a/src/main/avro/AlumniSchemasAmbiguous.avsc
+++ b/src/main/avro/AlumniSchemasAmbiguous.avsc
@@ -1,4 +1,3 @@
-// alumnischemasambiguous.avsc
 [
   {
     "type": "record",

--- a/src/main/avro/AlumniSchemasBackModels.avsc
+++ b/src/main/avro/AlumniSchemasBackModels.avsc
@@ -1,153 +1,118 @@
 [
-    {
-        "type": "record",
-        "namespace": "org.acme.avro.back.model",
-        "name": "AlumniGroupMembershipDto",
-        "fields":[
-            {
-                "name":"id", "type":"int"
-            },
-            {
-                "name":"faculty_number", "type":"int"
-            },
-            {
-                "name":"group", "type":"org.acme.avro.back.model.AlumniGroupDto"
-            },
-            {
-                "name": "average_score",
-                "type": ["null", "double"], "default": null
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "namespace": "org.acme.avro.back.model",
-        "name": "AlumniGroup",
-        "fields": [
-            {
-            "name": "id",
-            "type": "int"
-            },
-            {
-            "name": "faculty",
-            "type": "org.acme.avro.ambiguous.model.Faculty"
-            },
-            {
-            "name": "groupNumber",
-            "type": "int"
-            },
-            {
-            "name": "graduationYear",
-            "type": "int"
-            },
-            {
-            "name": "speciality",
-            "type": "org.acme.avro.ambiguous.model.Speciality"
-            },
-            {
-            "name": "memberships",
-            "type": {
-                "type": "array",
-                "items": "int"
-            }
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "namespace": "org.acme.avro.back.model",
-        "name": "AlumniDto",
-        "fields": [
-            {
-                "name": "faculty_number",
-                "type": "int"
-            },
-            {
-                "name": "full_name",
-                "type": "string"
-            },
-            {
-                "name": "birth_date",
-                "type": ["null", { "type": "int", "logicalType": "date" }],
-                "default": null
-            },
-            {
-                "name": "facebook_url",
-                "type": ["null", "string"],
-                "default": null
-            },
-            {
-                "name": "linkedin_url",
-                "type": ["null", "string"],
-                "default": null
-            },
-            {
-                "name": "degree",
-                "type": "org.acme.avro.ambiguous.model.Degree",
-                "default": null
-            },
-            {
-                "name": "faculty",
-                "type": "org.acme.avro.ambiguous.model.Faculty",
-                "default": null
-            },
-            {
-                "name": "created_at",
-                "type": {
-                    "type": "long",
-                    "logicalType": "timestamp-millis"
-                }
-            },
-            {
-                "name": "updated_at",
-                "type": {
-                    "type": "long",
-                    "logicalType": "timestamp-millis"
-                }
-            },
-            {
-                "name": "memberships",
-                "type": {
-                    "type": "array",
-                    "items": "org.acme.avro.back.model.AlumniGroupMembershipDto"
-                }
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "namespace": "org.acme.avro.back.model",
-        "name": "CompanyRecordDto",
-        "fields":[
-            {
-                "name":"id", "type":"int"
-            },
-            {
-                "name":"alumni", "type":"org.acme.avro.back.model.AlumniDto"
-            },
-            {
-                "name":"enrollment_date", "type": {
-                "type":"long",
-                "logicalType":"date"
-            }
-            },
-            {
-                "name":"discharge_date",
-                "type": ["null", { "type":"long", "logicalType":"date" }],
-                "default": null
-            },
-            {
-                "name":"position","type":"string"
-            },
-            {
-                "name":"company","type":"string"
-            },
-            {
-                "name":"created_at", "type": {
-                "type":"long",
-                "logicalType":"timestamp-millis"
-            }
-            }
-        ]
-    }
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.back.model",
+    "name": "AlumniGroupMembershipDto",
+    "fields": [
+      { "name": "id", "type": "int" },
+      { "name": "faculty_number", "type": "int" },
+      { "name": "group", "type": "org.acme.avro.back.model.AlumniGroupDto" },
+      {
+        "name": "average_score",
+        "type": ["null", "double"],
+        "default": null
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.back.model",
+    "name": "AlumniGroupDto",
+    "fields": [
+      { "name": "id", "type": "int" },
+      {
+        "name": "faculty",
+        "type": "org.acme.avro.ambiguous.model.Faculty"
+      },
+      { "name": "groupNumber", "type": "int" },
+      { "name": "graduationYear", "type": "int" },
+      {
+        "name": "speciality",
+        "type": "org.acme.avro.ambiguous.model.Speciality"
+      },
+      {
+        "name": "membershipIds",
+        "type": {
+          "type": "array",
+          "items": "int"
+        }
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.back.model",
+    "name": "AlumniDto",
+    "fields": [
+      { "name": "faculty_number", "type": "int" },
+      { "name": "full_name", "type": "string" },
+      {
+        "name": "birth_date",
+        "type": ["null", { "type": "int", "logicalType": "date" }],
+        "default": null
+      },
+      {
+        "name": "facebook_url",
+        "type": ["null", "string"],
+        "default": null
+      },
+      {
+        "name": "linkedin_url",
+        "type": ["null", "string"],
+        "default": null
+      },
+      {
+        "name": "degree",
+        "type": "org.acme.avro.ambiguous.model.Degree",
+        "default": null
+      },
+      {
+        "name": "faculty",
+        "type": "org.acme.avro.ambiguous.model.Faculty",
+        "default": null
+      },
+      {
+        "name": "created_at",
+        "type": { "type": "long", "logicalType": "timestamp-millis" }
+      },
+      {
+        "name": "updated_at",
+        "type": { "type": "long", "logicalType": "timestamp-millis" }
+      },
+      {
+        "name": "memberships",
+        "type": {
+          "type": "array",
+          "items": "org.acme.avro.back.model.AlumniGroupMembershipDto"
+        }
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.back.model",
+    "name": "CompanyRecordDto",
+    "fields": [
+      { "name": "id", "type": "int" },
+      {
+        "name": "alumni",
+        "type": "org.acme.avro.back.model.AlumniDto"
+      },
+      {
+        "name": "enrollment_date",
+        "type": { "type": "int", "logicalType": "date" }
+      },
+      {
+        "name": "discharge_date",
+        "type": ["null", { "type": "int", "logicalType": "date" }],
+        "default": null
+      },
+      { "name": "position", "type": "string" },
+      { "name": "company", "type": "string" },
+      {
+        "name": "created_at",
+        "type": { "type": "long", "logicalType": "timestamp-millis" }
+      }
+    ]
+  }
 ]

--- a/src/main/avro/AlumniSchemasBackModels.avsc
+++ b/src/main/avro/AlumniSchemasBackModels.avsc
@@ -2,28 +2,6 @@
     {
         "type": "record",
         "namespace": "org.acme.avro.back.model",
-        "name": "AlumniGroupDto",
-        "fields":[
-            {
-                "name":"id", "type":"int"
-            },
-            {
-                "name":"faculty", "type":"string"
-            },
-            {
-                "name":"group_number", "type":"int"
-            },
-            {
-                "name":"graduation_year", "type":"int"
-            },
-            {
-                "name":"speciality_name", "type":"string"
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "namespace": "org.acme.avro.back.model",
         "name": "AlumniGroupMembershipDto",
         "fields":[
             {
@@ -38,6 +16,40 @@
             {
                 "name": "average_score",
                 "type": ["null", "double"], "default": null
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "namespace": "org.acme.avro.back.model",
+        "name": "AlumniGroup",
+        "fields": [
+            {
+            "name": "id",
+            "type": "int"
+            },
+            {
+            "name": "faculty",
+            "type": "org.acme.avro.ambiguous.model.Faculty"
+            },
+            {
+            "name": "groupNumber",
+            "type": "int"
+            },
+            {
+            "name": "graduationYear",
+            "type": "int"
+            },
+            {
+            "name": "speciality",
+            "type": "org.acme.avro.ambiguous.model.Speciality"
+            },
+            {
+            "name": "memberships",
+            "type": {
+                "type": "array",
+                "items": "int"
+            }
             }
         ]
     },
@@ -71,11 +83,12 @@
             },
             {
                 "name": "degree",
-                "type": "string"
+                "type": "org.acme.avro.ambiguous.model.Degree",
+                "default": null
             },
             {
                 "name": "faculty",
-                "type": ["null", "string"],
+                "type": "org.acme.avro.ambiguous.model.Faculty",
                 "default": null
             },
             {

--- a/src/main/avro/AlumniSchemasBackModels.avsc
+++ b/src/main/avro/AlumniSchemasBackModels.avsc
@@ -1,7 +1,7 @@
 [
     {
         "type": "record",
-        "namespace": "org.acme.avro",
+        "namespace": "org.acme.avro.back.model",
         "name": "AlumniGroupDto",
         "fields":[
             {
@@ -23,7 +23,7 @@
     },
     {
         "type": "record",
-        "namespace": "org.acme.avro",
+        "namespace": "org.acme.avro.back.model",
         "name": "AlumniGroupMembershipDto",
         "fields":[
             {
@@ -33,7 +33,7 @@
                 "name":"faculty_number", "type":"int"
             },
             {
-                "name":"group", "type":"org.acme.avro.AlumniGroupDto"
+                "name":"group", "type":"org.acme.avro.back.model.AlumniGroupDto"
             },
             {
                 "name": "average_score",
@@ -43,7 +43,7 @@
     },
     {
         "type": "record",
-        "namespace": "org.acme.avro",
+        "namespace": "org.acme.avro.back.model",
         "name": "AlumniDto",
         "fields": [
             {
@@ -96,21 +96,21 @@
                 "name": "memberships",
                 "type": {
                     "type": "array",
-                    "items": "org.acme.avro.AlumniGroupMembershipDto"
+                    "items": "org.acme.avro.back.model.AlumniGroupMembershipDto"
                 }
             }
         ]
     },
     {
         "type": "record",
-        "namespace": "org.acme.avro",
+        "namespace": "org.acme.avro.back.model",
         "name": "CompanyRecordDto",
         "fields":[
             {
                 "name":"id", "type":"int"
             },
             {
-                "name":"alumni", "type":"org.acme.avro.AlumniDto"
+                "name":"alumni", "type":"org.acme.avro.back.model.AlumniDto"
             },
             {
                 "name":"enrollment_date", "type": {

--- a/src/main/avro/AlumniSchemasFrontDto.avsc
+++ b/src/main/avro/AlumniSchemasFrontDto.avsc
@@ -93,7 +93,7 @@
         }
       },
       {
-        "name": "memberships",
+        "name": "memberships_id",
         "type": {
           "type": "array",
           "items": "int"
@@ -110,7 +110,7 @@
         "name":"id", "type":"int"
       },
       {
-        "name":"alumni_faculty", "type":"int"
+        "name":"alumni_faculty_number", "type":"int"
       },
       {
         "name":"enrollment_date", "type": {

--- a/src/main/avro/AlumniSchemasFrontDto.avsc
+++ b/src/main/avro/AlumniSchemasFrontDto.avsc
@@ -3,69 +3,24 @@
     "type": "record",
     "namespace": "org.acme.avro.front.dto",
     "name": "AlumniGroupMembershipFrontDto",
-    "fields":[
-      {
-        "name":"id", "type":"int"
-      },
-      {
-        "name":"faculty_number", "type":"int"
-      },
-      {
-        "name":"group_number", "type":"int"
-      },
+    "fields": [
+      { "name": "id", "type": "int" },
+      { "name": "faculty_number", "type": "int" },
+      { "name": "group_number", "type": "int" },
       {
         "name": "average_score",
-        "type": ["null", "double"], "default": null
+        "type": ["null", "double"],
+        "default": null
       }
     ]
   },
-  {
-        "type": "record",
-        "namespace": "org.acme.avro.back.model",
-        "name": "AlumniGroup",
-        "fields": [
-            {
-            "name": "id",
-            "type": "int"
-            },
-            {
-            "name": "faculty",
-            "type": "string"
-            },
-            {
-            "name": "groupNumber",
-            "type": "int"
-            },
-            {
-            "name": "graduationYear",
-            "type": "int"
-            },
-            {
-            "name": "speciality",
-            "type": "string"
-            },
-            {
-              "name": "memberships",
-              "type": {
-                  "type": "array",
-                  "items": "int"
-              }
-            }
-        ]
-    },
   {
     "type": "record",
     "namespace": "org.acme.avro.front.dto",
     "name": "AlumniFrontDto",
     "fields": [
-      {
-        "name": "faculty_number",
-        "type": "int"
-      },
-      {
-        "name": "full_name",
-        "type": "string"
-      },
+      { "name": "faculty_number", "type": "int" },
+      { "name": "full_name", "type": "string" },
       {
         "name": "birth_date",
         "type": ["null", { "type": "int", "logicalType": "date" }],
@@ -81,10 +36,7 @@
         "type": ["null", "string"],
         "default": null
       },
-      {
-        "name": "degree",
-        "type": "string"
-      },
+      { "name": "degree", "type": "string" },
       {
         "name": "faculty",
         "type": ["null", "string"],
@@ -92,20 +44,14 @@
       },
       {
         "name": "created_at",
-        "type": {
-          "type": "long",
-          "logicalType": "timestamp-millis"
-        }
+        "type": { "type": "long", "logicalType": "timestamp-millis" }
       },
       {
         "name": "updated_at",
-        "type": {
-          "type": "long",
-          "logicalType": "timestamp-millis"
-        }
+        "type": { "type": "long", "logicalType": "timestamp-millis" }
       },
       {
-        "name": "memberships_id",
+        "name": "membership_ids",
         "type": {
           "type": "array",
           "items": "int"
@@ -117,39 +63,24 @@
     "type": "record",
     "namespace": "org.acme.avro.front.dto",
     "name": "CompanyRecordFrontDto",
-    "fields":[
+    "fields": [
+      { "name": "id", "type": "int" },
+      { "name": "alumni_faculty_number", "type": "int" },
       {
-        "name":"id", "type":"int"
+        "name": "enrollment_date",
+        "type": { "type": "int", "logicalType": "date" }
       },
       {
-        "name":"alumni_faculty_number", "type":"int"
-      },
-      {
-        "name":"enrollment_date", "type": {
-        "type":"long",
-        "logicalType":"date"
-      }
-      },
-      {
-        "name":"discharge_date",
-        "type": ["null", { "type":"long", "logicalType":"date" }],
+        "name": "discharge_date",
+        "type": ["null", { "type": "int", "logicalType": "date" }],
         "default": null
       },
+      { "name": "position", "type": "string" },
+      { "name": "company", "type": "string" },
       {
-        "name":"position","type":"string"
-      },
-      {
-        "name":"company","type":"string"
-      },
-      {
-        "name":"created_at", "type": {
-        "type":"long",
-        "logicalType":"timestamp-millis"
-      }
+        "name": "created_at",
+        "type": { "type": "long", "logicalType": "timestamp-millis" }
       }
     ]
-  },
-  {
-
   }
 ]

--- a/src/main/avro/AlumniSchemasFrontDto.avsc
+++ b/src/main/avro/AlumniSchemasFrontDto.avsc
@@ -2,28 +2,6 @@
   {
     "type": "record",
     "namespace": "org.acme.avro.front.dto",
-    "name": "AlumniGroupFrontDto",
-    "fields":[
-      {
-        "name":"id", "type":"int"
-      },
-      {
-        "name":"faculty", "type":"string"
-      },
-      {
-        "name":"group_number", "type":"int"
-      },
-      {
-        "name":"graduation_year", "type":"int"
-      },
-      {
-        "name":"speciality_name", "type":"string"
-      }
-    ]
-  },
-  {
-    "type": "record",
-    "namespace": "org.acme.avro.front.dto",
     "name": "AlumniGroupMembershipFrontDto",
     "fields":[
       {
@@ -41,6 +19,40 @@
       }
     ]
   },
+  {
+        "type": "record",
+        "namespace": "org.acme.avro.back.model",
+        "name": "AlumniGroup",
+        "fields": [
+            {
+            "name": "id",
+            "type": "int"
+            },
+            {
+            "name": "faculty",
+            "type": "string"
+            },
+            {
+            "name": "groupNumber",
+            "type": "int"
+            },
+            {
+            "name": "graduationYear",
+            "type": "int"
+            },
+            {
+            "name": "speciality",
+            "type": "string"
+            },
+            {
+              "name": "memberships",
+              "type": {
+                  "type": "array",
+                  "items": "int"
+              }
+            }
+        ]
+    },
   {
     "type": "record",
     "namespace": "org.acme.avro.front.dto",
@@ -136,5 +148,8 @@
       }
       }
     ]
+  },
+  {
+
   }
 ]

--- a/src/main/avro/AlumniSchemasFrontDto.avsc
+++ b/src/main/avro/AlumniSchemasFrontDto.avsc
@@ -1,0 +1,140 @@
+[
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.front.dto",
+    "name": "AlumniGroupFrontDto",
+    "fields":[
+      {
+        "name":"id", "type":"int"
+      },
+      {
+        "name":"faculty", "type":"string"
+      },
+      {
+        "name":"group_number", "type":"int"
+      },
+      {
+        "name":"graduation_year", "type":"int"
+      },
+      {
+        "name":"speciality_name", "type":"string"
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.front.dto",
+    "name": "AlumniGroupMembershipFrontDto",
+    "fields":[
+      {
+        "name":"id", "type":"int"
+      },
+      {
+        "name":"faculty_number", "type":"int"
+      },
+      {
+        "name":"group_number", "type":"int"
+      },
+      {
+        "name": "average_score",
+        "type": ["null", "double"], "default": null
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.front.dto",
+    "name": "AlumniFrontDto",
+    "fields": [
+      {
+        "name": "faculty_number",
+        "type": "int"
+      },
+      {
+        "name": "full_name",
+        "type": "string"
+      },
+      {
+        "name": "birth_date",
+        "type": ["null", { "type": "int", "logicalType": "date" }],
+        "default": null
+      },
+      {
+        "name": "facebook_url",
+        "type": ["null", "string"],
+        "default": null
+      },
+      {
+        "name": "linkedin_url",
+        "type": ["null", "string"],
+        "default": null
+      },
+      {
+        "name": "degree",
+        "type": "string"
+      },
+      {
+        "name": "faculty",
+        "type": ["null", "string"],
+        "default": null
+      },
+      {
+        "name": "created_at",
+        "type": {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      },
+      {
+        "name": "updated_at",
+        "type": {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      },
+      {
+        "name": "memberships",
+        "type": {
+          "type": "array",
+          "items": "int"
+        }
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "namespace": "org.acme.avro.front.dto",
+    "name": "CompanyRecordFrontDto",
+    "fields":[
+      {
+        "name":"id", "type":"int"
+      },
+      {
+        "name":"alumni_faculty", "type":"int"
+      },
+      {
+        "name":"enrollment_date", "type": {
+        "type":"long",
+        "logicalType":"date"
+      }
+      },
+      {
+        "name":"discharge_date",
+        "type": ["null", { "type":"long", "logicalType":"date" }],
+        "default": null
+      },
+      {
+        "name":"position","type":"string"
+      },
+      {
+        "name":"company","type":"string"
+      },
+      {
+        "name":"created_at", "type": {
+        "type":"long",
+        "logicalType":"timestamp-millis"
+      }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Separate backend and frontend schemas.

Now frontend schemas contain only primitive types and arrays, this schemas will be used for tranfering data from frontend service to backend service.

Backend schemas contain full information about object and will be used for trasfering data from backend service to frontend